### PR TITLE
Added support for basic markup

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -1120,9 +1120,9 @@ write_markup_text :: proc(w: io.Writer, lines: []string) {
 		}
 
 		// Lists
-		if trimmed_line[0] == '-' {
+		if trimmed_line[0] == '-' || trimmed_line[0] == '*' {
 			io.write_string(w, "<ul>")
-			for len(trimmed_line) > 0 && trimmed_line[0] == '-' {
+			for len(trimmed_line) > 0 && (trimmed_line[0] == '-' || trimmed_line[0] == '*') {
 				io.write_string(w, "<li>")
 				trimmed_line_to_write := trimmed_line[1:]
 				write_markup_single_line(w, &trimmed_line_to_write)

--- a/main.odin
+++ b/main.odin
@@ -1120,9 +1120,9 @@ write_markup_text :: proc(w: io.Writer, lines: []string) {
 				
 				if next_backtick_index < 0 {
 					// Multi-line code block
-					// TODO(fkp): Other languages
-					io.write_string(w, "<pre><code class=\"hljs\" data-lang=\"odin\">")
-					io.write_string(w, line)
+					
+					//io.write_string(w, "<pre><code class=\"hljs\" data-lang=\"odin\">")
+					fmt.wprintf(w, "<pre><code class=\"%s\">", line if line != "" else "odin");
 
 					for {
 						i += 1

--- a/main.odin
+++ b/main.odin
@@ -1101,7 +1101,7 @@ write_markup_single_line :: proc(w: io.Writer, line: ^string) {
 
 	// Normal text
 	io.write_string(w, line^)
-	io.write_string(w, "\n")
+	io.write_string(w, " ")
 }
 
 write_markup_text :: proc(w: io.Writer, lines: []string) {

--- a/main.odin
+++ b/main.odin
@@ -1157,7 +1157,7 @@ write_markup_text :: proc(w: io.Writer, lines: []string) {
 
 		// Normal text
 		io.write_string(w, line)
-		io.write_string(w, "<br>")
+		io.write_string(w, "\n")
 	}
 
 	io.write_string(w, "</p>\n")
@@ -1176,32 +1176,6 @@ write_docs :: proc(w: io.Writer, docs: string) {
 		append(&lines, line)
 	}
 	
-	// Removes leading tabs that are common to every line
-	unindent_loop: for {
-		// Checks if every line of the comment has a leading tab
-		has_non_empty_line := false
-		for line in lines {
-			if len(line) > 0 {
-				has_non_empty_line = true
-				if line[0] != '\t' {
-					break unindent_loop
-				}
-			}
-		}
-
-		if !has_non_empty_line {
-			// Every line is now blank
-			break unindent_loop
-		}
-
-		// Remove the leading tab from every line
-		for line in &lines {
-			if len(line) > 0 && line[0] == '\t' {
-				line = line[1:]
-			}
-		}
-	}
-
 	write_markup_text(w, lines[:])
 }
 


### PR DESCRIPTION
This PR is intended to be used with PR1561 in the main Odin repository (which unindents common indents).

The markup supported is fairly limited, just lists (unordered, creates by starting a line with `-`) and code. Newlines within paragraphs in the doc comment are collapsed to spaces (as they do currently), to create a paragraph break use an empty comment line. 

Inline code is created with single backticks, and is restricted to a single line. Unclosed backticks are ignored.

Code blocks are created using triple backticks, and are restricted to being multi-line only. Everything on the line after the triple backticks are considered to be the language (e.g. `\```json` for JSON highlighting or `\```nohighlight` for none (ignore the backslashes, Github markdown is a bit finicky)). The default language is Odin. 

If there is text at the start of the line (before the start of the triple backticks), it is treated as a summary and will create a collapsible code block. If the triple backticks are the first thing on the line, there will be no summary/details (just the code).

Text that is only indented is no longer treated as code.


The following example code can be used to showcase the supported markup features:
```
/*
	This is a comment that is too long to fit on a
	single comment line but is still effectively a
	single sentence.
	
	Next paragraph.

	- List one
	- List two
	- List three

	- Separate list one
	- Separate `list` two
	- Separate list `three

	Some `inline` code and some `more`

	Example `code`: ```
	package main
	import "core:fmt"

	main :: proc() {
		fmt.printf("Hello, Odin!\n")
	}
	```

	```plaintext
	package main
	import "core:fmt"

	main :: proc() {
		fmt.printf("Hello, Odin!\n")
	}
	```
*/
test :: proc() {}
```

This produces the following result:
![image](https://user-images.githubusercontent.com/37253999/155870634-b2b9c8ce-e226-40e4-869b-431ce13e9c81.png)
