### PR TITLE
Fix make_directory mode on Unix systems

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -28,6 +28,14 @@ vendor_pkgs_to_use: map[string]^doc.Pkg // trimmed path
 pkg_to_path: map[^doc.Pkg]string // trimmed path
 pkg_to_collection: map[^doc.Pkg]^Collection
 
+// On Unix systems we need to set the directory mode so that we
+// can read/write from them
+when os.OS == .Darwin || os.OS == .Linux || os.OS == .FreeBSD {
+     directory_mode :: 0o775
+} else {
+     directory_mode :: 0
+}
+
 Collection :: struct {
 	name: string,
 	pkgs_to_use: ^map[string]^doc.Pkg,
@@ -96,7 +104,7 @@ recursive_make_directory :: proc(path: string, prefix := "") {
 	if prefix != "" {
 		path_to_make = fmt.tprintf("%s/%s", prefix, head)
 	}
-	os.make_directory(path_to_make, 0)
+	os.make_directory(path_to_make, directory_mode)
 	if tail != "" {
 		recursive_make_directory(tail, path_to_make)
 	}
@@ -248,7 +256,7 @@ generate_packages :: proc(b: ^strings.Builder, collection: ^Collection, dir: str
 		write_html_header(w, fmt.tprintf("%s library - pkg.odin-lang.org", dir))
 		write_collection_directory(w, collection)
 		write_html_footer(w, true)
-		os.make_directory(dir, 0)
+		os.make_directory(dir, directory_mode)
 		os.write_entire_file(fmt.tprintf("%s/index.html", dir), b.buf[:])
 	}
 


### PR DESCRIPTION
Odin: commit `28fc29f28562ebe5a1488b72e3507cc9d088b65c`
Platform: `macOS`

## Problem

When I tried to build the documentation locally on my MacBook, no files other than the main index.html and `core` and `vendor` directories were created.

I inspected the directories and saw that `core` and `vendor` didn't have any permissions for reading/executing.

Commands used to build the documentation (inside the pkg.odin-lang.org directory):

```
../Odin/odin build . -out:odin-html-docs

mkdir website
cd website
../odin-html-docs ../../Odin/all.odin-doc
```

## Fix

On Unix systems, creating a directory with a permission mask/mode of 0 prevents
any writes/reads to those directories. When that happens, the program is unable to write
the documentation files.

This commit changes the code to set the correct mode for Unix (Darwin, Linux, FreeBSD) and
keep using zero for all others.

With this patch in place, I'm able to generate the documentation on my laptop.