### PR TITLE
Show last of muti-line proc args

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -932,10 +932,15 @@ write_type :: proc(using writer: ^Type_Writer, type: doc.Type, flags: Write_Type
 
 			prev_field_group_index := i32le(-1)
 			prev_field_index := 0
-			for entity_index, i in type_entities {
-				e := &entities[entity_index]
-				if i+1 == len(type_entities) || prev_field_group_index != e.field_group_index {
-					prev_field_group_index = e.field_group_index
+			for i := 0; i <= len(type_entities); i += 1 {
+				e: ^doc.Entity
+				if i != len(type_entities) {
+					e = &entities[type_entities[i]]
+				}
+				if i+1 >= len(type_entities) || prev_field_group_index != e.field_group_index {
+					if i != len(type_entities) {
+						prev_field_group_index = e.field_group_index
+					}
 					group := type_entities[prev_field_index:i]
 					if len(group) > 0 {
 						append(&groups, group)


### PR DESCRIPTION
Fix a bug where the last argument of a proc wasn't shown if it spans multiple lines. For an example of this not working in the current state, compare [https://pkg.odin-lang.org/vendor/raylib/#DrawBillboardPro](https://pkg.odin-lang.org/vendor/raylib/#DrawBillboardPro) and [https://github.com/odin-lang/Odin/blob/master/vendor/raylib/raylib.odin#L1413](https://github.com/odin-lang/Odin/blob/master/vendor/raylib/raylib.odin#L1413), where the last 'tint' argument isn't shown in the online documentation.