### PR TITLE
Updated package page's copyright year.

### DIFF
--- a/footer.txt.html
+++ b/footer.txt.html
@@ -36,7 +36,7 @@
 			</ul>
 			</nav>
 		</div>
-		<div class="mt-4 text-muted">© 2016–2022 Ginger Bill</div>
+		<div class="mt-4 text-muted">© 2016–2023 Ginger Bill</div>
 	</div>
 </footer>
 


### PR DESCRIPTION
I couple days ago I submitted a fix for the main site's copyright, updating 2022 to 2023, but I didn't realize that the footer for the package directory page was separate.

Thus, this commit updates the year here too.