### PR TITLE
Various improvements to styling and layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -18,6 +18,10 @@ hr.collection-hr {
 	padding: 0;
 }
 
+b {
+    font-weight: bold;
+}
+
 
 .doc-directory tr {
 	padding-left: 1em!important;
@@ -254,4 +258,9 @@ details.code-example > summary {
 
 .pkg-breadcrumb {
 	padding-top: 1rem;
+}
+
+.doc-list {
+    display: list-item;
+    margin-left: 1.5em;
 }


### PR DESCRIPTION
* Add bullet point support via `- `. We use span's with  item list display kind to embed in a paragraph.
* Parse output blocks and append them to examples
* Create specific markup for subtitles like `Inputs:` and `Returns:`. This reduces the amount of clutter we need to markup the actual comments in the code and make formatting consistent with `Example:` and `Output:`
For example rather than writing `**Returns**  ` we can just write `Returns:`
* Make `<b>` be just bold (the default bolder looked unreadable on `Example:`)

Visually the documentation for strings now looks like
![image](https://user-images.githubusercontent.com/16159123/229319702-d7509cc3-246b-45e1-bd6e-ef2f19f15237.png)
