### PR TITLE
search: allow focusing on input with `Ctrl+K` or `/`

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -1452,7 +1452,17 @@ write_search :: proc(w: io.Writer, kind: enum { Package, Collection, All}) {
 	case .Collection: class = "odin-search-collection"
 	case .All:        class = "odin-search-all"
 	}
-	fmt.wprintf(w, `<input type="search" id="odin-search" class="%s" autocomplete="off" spellcheck="false" placeholder="Fuzzy Search...">`, class)
+	fmt.wprintf(w, `
+		<div class="odin-search-wrapper">
+			<input type="search" id="odin-search" class="%s" autocomplete="off" spellcheck="false" placeholder="Fuzzy Search...">
+			<div class="odin-search-shortcut">
+				<div class="odin-search-key key-macos">⌘K</div>
+				<div class="odin-search-key key-windows">Ctrl+K</div>
+				<span class="odin-search-or">or</span>
+				<div class="odin-search-key">/</div>
+			</div>
+		</div>
+	`, class)
 	fmt.wprintln(w)
 
 	switch kind {

--- a/search.js
+++ b/search.js
@@ -1,5 +1,20 @@
 "use strict";
 
+const userAgent = navigator.userAgent;
+const osList = [
+	{lookFor: "Win", name: "windows"},
+	{lookFor: "Mac", name: "macos"},
+	{lookFor: "X11", name: "unix"},
+	{lookFor: "Linux", name: "linux"},
+	{lookFor: "iPhone", name: "ios"},
+	{lookFor: "Android", name: "android"},
+];
+for (const os of osList) {
+	if (userAgent.includes(os.lookFor)) {
+		document.body.classList.add(`os-${os.name}`);	
+	}	
+}
+
 var odin_pkg_name;
 
 let odin_search = document.getElementById("odin-search");
@@ -386,12 +401,12 @@ if (odin_search) {
 			}
 			ev.stopPropagation(); return;
 		}, false);
-
-		window.addEventListener("keydown", ev => {
-			if ((ev.key === 'k' && (ev.metaKey || ev.ctrlKey)) || ev.key === '/') {
-				ev.preventDefault();
-				odin_search.focus();
-			}
-		});
 	}
+
+	window.addEventListener("keydown", ev => {
+		if ((ev.key === 'k' && (ev.metaKey || ev.ctrlKey)) || ev.key === '/') {
+			ev.preventDefault();
+			odin_search.focus();
+		}
+	});
 }

--- a/search.js
+++ b/search.js
@@ -386,5 +386,11 @@ if (odin_search) {
 			}
 			ev.stopPropagation(); return;
 		}, false);
+
+		window.addEventListener("keydown", ev => {
+			if ((ev.key == "k" && ev.metaKey) || ev.key == "/") {
+				odin_search.focus();
+			}
+		});
 	}
 }

--- a/search.js
+++ b/search.js
@@ -388,7 +388,7 @@ if (odin_search) {
 		}, false);
 
 		window.addEventListener("keydown", ev => {
-			if (ev.key === 'k' && (ev.metaKey || ev.ctrlKey)) {
+			if ((ev.key === 'k' && (ev.metaKey || ev.ctrlKey)) || ev.key === '/') {
 				ev.preventDefault();
 				odin_search.focus();
 			}

--- a/search.js
+++ b/search.js
@@ -388,7 +388,8 @@ if (odin_search) {
 		}, false);
 
 		window.addEventListener("keydown", ev => {
-			if ((ev.key == "k" && ev.metaKey) || ev.key == "/") {
+			if (ev.key === 'k' && (ev.metaKey || ev.ctrlKey)) {
+				ev.preventDefault();
 				odin_search.focus();
 			}
 		});

--- a/style.css
+++ b/style.css
@@ -26,7 +26,6 @@ b {
     font-weight: bold;
 }
 
-
 .doc-directory tr {
 	padding-left: 1em!important;
 	border-top: 1px solid #ccc!important;
@@ -251,19 +250,88 @@ h1.odin-package-header {
 	padding-top: 3rem !important;
 }
 
+.odin-search-wrapper {
+	position: relative;
+	margin-top: 1rem;
+}
+
+.odin-search-shortcut {
+	display: flex;
+	align-items: center;
+	column-gap: 0.25rem;
+	position: absolute;
+	top: 50%;
+	right: 0.5rem;
+	transform: translateY(-50%);
+	z-index: 1001;
+	user-select: none;
+	pointer-events: none;
+	font-size: 0.75rem;
+	background-color: white;
+	opacity: 0.5;
+}
+
+.os-linux .odin-search-shortcut {
+	display: flex;
+}
+
+.odin-search-key {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	min-width: 30px;
+	height: 30px;
+	padding: 0.25rem;
+	border: 1px solid rgba(0,0,0,0.2);
+	border-radius: 0.25rem;
+}
+
+.key-macos, .key-windows, .odin-search-or {
+	display: none;
+}
+
+.os-macos .key-macos,
+.os-macos .odin-search-or {
+	display: flex;
+}
+
+.os-windows .key-windows,
+.os-windows .odin-search-or,
+.os-linux .key-windows,
+.os-linux .odin-search-or {
+	display: flex;
+}
+
 #odin-search {
 	position: relative!important;
 	z-index: 1000;
 	width: 100%;
 	height: 3rem;
 	font-size: 1.5rem;
-	margin-top: 1rem;
 	border: 1px solid #888;
 	padding-left:  0.5rem;
 	padding-right: 0.5rem;
 	border-radius: 0.25rem;
 }
 
+.os-ios #odin-search,
+.os-android #odin-search {
+	padding-right: 0.5rem !important;
+}
+
+.os-macos #odin-search {
+	padding-right: 6rem;
+}
+
+.os-windows #odin-search,
+.os-linux #odin-search {
+	padding-right: 6.5rem;
+}
+
+.os-ios .odin-search-shortcut,
+.os-android .odin-search-shortcut {
+	display: none;
+}
 
 #odin-search-results {
 	padding-left: 0;


### PR DESCRIPTION
<img width="906" alt="image" src="https://github.com/odin-lang/pkg.odin-lang.org/assets/41843151/5b381caf-8223-4bcc-a30b-8185c1ed81c6">

<img width="873" alt="image" src="https://github.com/odin-lang/pkg.odin-lang.org/assets/41843151/70a5a612-b3c5-4740-b49a-42c3f61d3523">


OS detection via UA is set as a class in the `<body>` tag, other features in the site could use this feature as well