### PR TITLE
Fix headers overlapping content above

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
 
 html {
 	scroll-behavior: auto;
+	scroll-padding-top: 59px;
 }
 
 table.directory {
@@ -132,6 +133,15 @@ section.documentation {
 
 section.documentation h3 {
 	font-size: calc(1.1rem + .2vw);
+}
+
+section.documentation h1,
+section.documentation h2,
+section.documentation h3,
+section.documentation h4,
+section.documentation h5 {
+	margin-top: 0;
+	padding-top: 1.5rem;
 }
 
 .pkg-index h3 {


### PR DESCRIPTION
This commit overrides the margin-top and padding-top css rules that were set for heading elements in main content. The removed values probably were added to prevent the heading element from going under the header element. However, this was causing the heading elements to expand beyond their top over to the preceding content, rendering the links and text inaccessible.