### PR TITLE
Escape less than in doc strings

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -1266,7 +1266,7 @@ write_type :: proc(using writer: ^Type_Writer, type: doc.Type, flags: Write_Type
 }
 
 write_doc_line :: proc(w: io.Writer, text: string) {
-	text := text
+	text := escape_html_string(text)
 	for len(text) != 0 {
 		if strings.count(text, "`") >= 2 {
 			n := strings.index_byte(text, '`')


### PR DESCRIPTION
There is a problem with core:encoding/xml, where the comments include a lot of < characters, which are not escaped to &lt; and the result is that the static site is not properly rendered for this package. I am not sure but I hope that this change will escape < in the comments, so that this problem is fixed.