### PR TITLE
Fix the fix of escaping html in docs

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -824,7 +824,7 @@ write_type :: proc(using writer: ^Type_Writer, type: doc.Type, flags: Write_Type
 		if docs == "" {
 			return
 		}
-		docs = escape_html_string(docs)
+		docs := escape_html_string(docs)
 		lines := strings.split_lines(docs)
 		defer delete(lines)
 		for i := len(lines)-1; i >= 0; i -= 1 {
@@ -849,7 +849,7 @@ write_type :: proc(using writer: ^Type_Writer, type: doc.Type, flags: Write_Type
 		if comment == "" {
 			return
 		}
-		comment = escape_html_string(comment)
+		comment := escape_html_string(comment)
 		for _ in 0..< padding {
 			io.write_byte(w, ' ')
 		}


### PR DESCRIPTION
It turns out that I tried to assign to a procedure parameter which is a syntax error, so I changed this to creating a variable with the same name to shadow the parameter.