### PR TITLE
Add search query parameter

### DIFF
--- a/resources/search.js
+++ b/resources/search.js
@@ -466,6 +466,12 @@ if (odin_search) {
 			return;
 		}
 
+		let url_parameters = new URLSearchParams(window.location.search);
+		if (url_parameters.has("q")) {
+			let search_query = url_parameters.get("q");
+			odin_search.value = search_query.trim();
+			odin_search_input(null);
+		}
 
 		odin_search.addEventListener("input", ev => {
 			odin_search_input(ev);


### PR DESCRIPTION
I think it could be handy to have a search query param for the search. That way people could add the search to their browser search engine shortcuts.

**Changes:**
* Adds `q` as a search query parameter. On page load, this sets the search input value and triggers a search.

**Open questions:**
* `odin_search_input` has an `ev` parameter that is never used. Should I remove it or call the function with `null`, like I do at the moment?

**Notes:**
* The value returned when calling `get` on the `URLSearchParams` object seems to already be url decoded.

Let me know if this is something you'd consider to add or if you want changes made.