### PR TITLE
Fix hide_base handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Here is an example config file with comments, you should remove any comments so 
 	// Hides the core packages from the menu, homepage and search results,
 	// they are still there so that links from your own packages work.
 	"hide_core": true,
+	"hide_base": false,
 	// If your docs are going to be on a subpath of your domain, for example: `name.github.io/repo`
 	// You can provide a url_prefix here to make the paths line up, if your docs will be at the root of the domain, leave this out.
 	"url_prefix": "/repo",

--- a/config.odin
+++ b/config.odin
@@ -130,6 +130,10 @@ config_merge_from_file :: proc(c: ^Config, file: string) -> (file_ok: bool, err:
 			collection.hidden = true
 		}
 
+		if c.hide_base && (collection.name == "base") {
+			collection.hidden = true
+		}
+
 		if c.url_prefix != "" {
 			new_base_url := strings.concatenate({c.url_prefix, collection.base_url})
 			delete(collection.base_url)


### PR DESCRIPTION
The `base` collection was not being set to hidden in the config when `hide_base` was true. This resulted in the sidebar to always show the `Base Library`.

Also added `hide_base` to the example config.