### PR TITLE
Ensure collections are created before packages

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -71,10 +71,6 @@ main :: proc() {
 	defer strings.builder_destroy(&b)
 	w := strings.to_writer(&b)
 
-	for c in cfg.collections {
-		generate_packages_in_collection(&b, c)
-	}
-
 
 	for c in cfg.collections {
 		if cfg.hide_core && (c.name == "core" || c.name == "vendor") {
@@ -113,6 +109,8 @@ main :: proc() {
 		write_html_footer(w, true)
 		os.make_directory(dir, DIRECTORY_MODE)
 		os.write_entire_file(fmt.tprintf("%s/index.html", dir), b.buf[:])
+
+		generate_packages_in_collection(&b, collection)
 	}
 
 


### PR DESCRIPTION
Generating documentation for the first time previously resulted in a missing directory tree. The problem was due to the package directories being created before the collection directories, on which they depended.

With this PR, the order of directory creation is corrected:

Collection directories are created first.
Package directories are created next.

Should be fixing #37 (while I believe the config.json there might wrong).