### PR TITLE
Set icon as favicon.svg

### DIFF
--- a/resources/header-lower.txt.html
+++ b/resources/header-lower.txt.html
@@ -1,3 +1,4 @@
+	<link rel="icon" href="/favicon.svg">
 	<link rel="stylesheet" type="text/css" href="https://odin-lang.org/scss/custom.min.css">
 	<link rel=stylesheet href="//odin-lang.org/lib/highlight/styles/github-dark.min.css">
 	<script src="//odin-lang.org/lib/highlight/highlight.min.js"></script>


### PR DESCRIPTION
Browsers will by default try to load favicon.ico, but we are using an SVG file.

Should resolve https://github.com/odin-lang/pkg.odin-lang.org/issues/30