### PR TITLE
Fix broken URLs referenced in docs

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -1659,7 +1659,7 @@ write_markup_text :: proc(w: io.Writer, s_: string, code_inline := false) {
 					scheme, host, path, queries, fragment := net.split_url(url, context.temp_allocator)
 					scheme = strings.to_lower(scheme, context.temp_allocator)
 					host  = strings.to_lower(host, context.temp_allocator)
-					url = net.join_url(scheme, host, path, queries, fragment)
+					url = net.join_url(scheme, host, path, queries, fragment, context.temp_allocator)
 
 					if strings.has_suffix(host, cfg.domain) {
 						// Same domain as cfg.domain

--- a/main.odin
+++ b/main.odin
@@ -1655,22 +1655,23 @@ write_markup_text :: proc(w: io.Writer, s_: string, code_inline := false) {
 
 					io.write_string(w, s[latest_index:index])
 
-					_, host, _, _, _ := net.split_url(url, context.temp_allocator)
+					// Case-normalize URI per RFC 3986 §6.2.2.1
+					scheme, host, path, queries, fragment := net.split_url(url, context.temp_allocator)
+					scheme = strings.to_lower(scheme, context.temp_allocator)
 					host  = strings.to_lower(host, context.temp_allocator)
-					url_ := strings.to_lower(url,  context.temp_allocator)
+					url = net.join_url(scheme, host, path, queries, fragment)
 
 					if strings.has_suffix(host, cfg.domain) {
 						// Same domain as cfg.domain
-						fmt.wprintf(w, `<a href="%s">`, url_)
+						fmt.wprintf(w, `<a href="%s">`, url)
 					} else {
 						// External domain, open in new tab.
-						fmt.wprintf(w, `<a href="%s" target="_blank">`, url_)
+						fmt.wprintf(w, `<a href="%s" target="_blank">`, url)
 					}
 					io.write_string(w, text)
 					io.write_string(w, "</a>")
 					latest_index = end_bracket + 1
 					index = latest_index
-
 				}
 			}
 		case '*':


### PR DESCRIPTION
Lowercasing the entire URL caused some URLs referenced in the documentation, such as those in [fnmatch](https://pkg.odin-lang.org/core/sys/posix/#fnmatch), [Atomic_Memory_Order](https://pkg.odin-lang.org/core/sync/#Atomic_Memory_Order) and [xxhash](https://pkg.odin-lang.org/core/hash/xxhash/), to break.

This was fixed by lowercasing only the scheme and host, assuming URI Generic Syntax per [RFC 3986 §6.2.2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1).