### PR TITLE
Allow spaces and separators in match even if there are none in string

### DIFF
--- a/resources/search.js
+++ b/resources/search.js
@@ -60,7 +60,7 @@ if (odin_search) {
 		return x;
 	}
 
-
+	// matches one string against a pattern
 	function fuzzy_match(str, pattern) {
 		// Score consts
 		const ADJACENCY_BONUS            =  5; // bonus for adjacent matches
@@ -101,7 +101,7 @@ if (odin_search) {
 
 		let matched_indices = [];
 
-		// Loop over strings
+		// Loop over string
 		while (str_idx != str_length) {
 			let pattern_char = pattern_idx != pattern_length ? pattern.charAt(pattern_idx) : null;
 			let str_char     = str.charAt(str_idx);
@@ -183,7 +183,14 @@ if (odin_search) {
 			if (str_char == '.') {
 				seen_dot = true;
 			}
-			prev_separator = str_char == '_' || str_char == ' ' || str_char == '.';
+
+			// Match separator
+			if (str_char == '_' || str_char == ' ' || str_char == '.') {
+				prev_separator = true;
+				if (!prev_matched) {
+					pattern_idx += 1
+				}
+			}
 
 			str_idx += 1;
 		}

--- a/resources/search.js
+++ b/resources/search.js
@@ -185,11 +185,9 @@ if (odin_search) {
 			}
 
 			// Match separator
-			if (str_char == '_' || str_char == ' ' || str_char == '.') {
-				prev_separator = true;
-				if (!prev_matched) {
-					pattern_idx += 1
-				}
+			prev_separator = str_char == '_' || str_char == ' ' || str_char == '.';
+			if (prev_separator && !prev_matched) {
+				pattern_idx += 1
 			}
 
 			str_idx += 1;


### PR DESCRIPTION
I noticed that if try to match multiple words delimited by a space you will get no matches, since there are no spaces in function names and similar. This patch effectively allows delimiters to be in the pattern and not in the string.

This is a band-aid to enable the fuzzy search behavior that I think most people will expect. If you guys are open to it, I'm interested in rewriting the matcher to support things like matching multiple parts with different orders.

Thanks!